### PR TITLE
Remove redundant fields for record timestamps

### DIFF
--- a/callmetadata.schema.json
+++ b/callmetadata.schema.json
@@ -59,16 +59,6 @@
                     "example": "XYZ Energy",
                     "description": "The name on the consuming app for the connection"
                 },
-                "offset": {
-                    "type": "string",
-                    "example": "00:00:20",
-                    "description": "For shoutdowns, the offset in the recording for this call. Shoutdown recordings may include more than one call Record"
-                },
-                "duration": {
-                    "type": "integer",
-                    "example": 35,
-                    "description": "The duration of the call in seconds"
-                },
                 "startTime": {
                     "type": "string",
                     "format": "date-time",

--- a/callmetadata.schema.json
+++ b/callmetadata.schema.json
@@ -110,10 +110,10 @@
             ],
             "description": "The device as used to handle the call"
         },
-        "callStartTime": {
+        "recordingStartTime": {
             "type": "string",
             "format": "date-time",
-            "description": "Start time of the call in ISO 8601 UTC time time format",
+            "description": "Start date and time of the recording in ISO 8601 UTC time format",
             "example": "2016-06-18T07:50:30Z"
         },
         "callDirection": {

--- a/callmetadata.schema.json
+++ b/callmetadata.schema.json
@@ -63,13 +63,13 @@
                     "type": "string",
                     "format": "date-time",
                     "example": "2016-06-18T07:50:30Z",
-                    "description": "The time when the call started"
+                    "description": "Date and time when this call record was started"
                 },
                 "stopTime": {
                     "type": "string",
                     "format": "date-time",
                     "example": "2016-06-18T08:05:15Z",
-                    "description": "The time when the call terminated"
+                    "description": "Date and time when this call record was finished"
                 },
                 "participants": {
                     "type": "array",


### PR DESCRIPTION
This is a PR to fix #29.

It removes redundancy between callRecord startTime/endTime and offset/duration fields. This is possible by renaming callStartTime to recordingStartTime, so it can be used as base for all date and time fields in the metadata.